### PR TITLE
Change Microsoft Yahei font priority

### DIFF
--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -16,8 +16,8 @@ color-widget-background = #ddd
 color-widget-border = #ccc
 
 // Fonts
-font-sans = "open sans", "Helvetica Neue", "Microsoft Yahei", Helvetica, Arial, sans-serif
-font-serif = Georgia, "Times New Roman", "Microsoft Yahei", serif
+font-sans = "open sans", "Helvetica Neue", Helvetica, Arial, "Microsoft Yahei", sans-serif
+font-serif = Georgia, "Times New Roman", Arial, "Microsoft Yahei", serif
 font-mono = "Source Code Pro", Consolas, Monaco, Menlo, Consolas, monospace
 font-size = 14px
 line-height = 1.6em


### PR DESCRIPTION
With this font prioritised over Arial it causes apostrophes to be rendered with additional spacing after the quotation.
