### PR TITLE
add paypal code block

### DIFF
--- a/layout/paypal.ejs
+++ b/layout/paypal.ejs
@@ -1,0 +1,43 @@
+<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="paypal">
+  <input type="hidden" name="cmd" value="_xclick">
+  <input type="hidden" name="business" value="accounts@redbrick.dcu.ie">
+  <input type="hidden" name="item_name" value="Membership">
+  <input type="hidden" name="item_number" value="Membership Payment">
+  <table id="paypalform">
+    <tbody>
+      <tr>
+        <td>
+          <input type="radio" name="amount" value="4.50">
+          Student
+        </td>
+        <td>
+          €4.00 + 50c Paypal fees
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <input type="radio" name="amount" value="8.63">
+          Associate or Staff</td><td>€8.00 + 63c Paypal fees
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <input type="radio" name="amount" value="20.00">
+          Associate(Including Donation)
+        </td>
+        <td>
+          €20.00
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2" align="center">
+          <input type="image" name="submit" src="http://www.paypal.com/en_US/i/btn/x-click-but06.gif" alt="Make payments with PayPal - it's fast, free and secure!">
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <input type="hidden" name="no_shipping" value="1">
+  <input type="hidden" name="ah" value="0">
+  <input type="hidden" name="currency_code" value="EUR">
+  <input type="hidden" name="bn" value="PayPal_Mike">
+</form>

--- a/layout/paypal.ejs
+++ b/layout/paypal.ejs
@@ -3,39 +3,35 @@
   <input type="hidden" name="business" value="accounts@redbrick.dcu.ie">
   <input type="hidden" name="item_name" value="Membership">
   <input type="hidden" name="item_number" value="Membership Payment">
-  <table id="paypalform">
-    <tbody>
-      <tr>
-        <td>
-          <input type="radio" name="amount" value="4.50">
-          Student
-        </td>
-        <td>
-          €4.00 + 50c Paypal fees
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <input type="radio" name="amount" value="8.63">
-          Associate or Staff</td><td>€8.00 + 63c Paypal fees
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <input type="radio" name="amount" value="20.00">
-          Associate(Including Donation)
-        </td>
-        <td>
-          €20.00
-        </td>
-      </tr>
-      <tr>
-        <td colspan="2" align="center">
-          <input type="image" name="submit" src="http://www.paypal.com/en_US/i/btn/x-click-but06.gif" alt="Make payments with PayPal - it's fast, free and secure!">
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <div id="paypalform" class="paypal">
+    <div class="paypal__selection">
+      <div class="paypal__selection__detials">
+        <label><input type="radio" name="amount" value="4.50"> Student</label>
+      </div>
+      <div class="paypal__selection__price">
+        €4.00 + 50c Paypal fees
+      </div>
+    </div>
+    <div class="paypal__selection">
+      <div class="paypal__selection__detials">
+        <label><input type="radio" name="amount" value="8.63"> Associate or Staff</label>
+      </div>
+      <div class="paypal__selection__price">
+        €8.00 + 63c Paypal fees
+      </div>
+    </div>
+    <div class="paypal__selection">
+      <div class="paypal__selection__detials">
+        <label><input type="radio" name="amount" value="20.00"> Associate(Including Donation)</label>
+      </div>
+      <div class="paypal__selection__price">
+        €20.00
+      </div>
+    </div>
+    <div class="paypal__button">
+      <input type="image" name="submit" src="http://www.paypal.com/en_US/i/btn/x-click-but06.gif" alt="Make payments with PayPal - it's fast, free and secure!">
+    <div>
+  </div>
   <input type="hidden" name="no_shipping" value="1">
   <input type="hidden" name="ah" value="0">
   <input type="hidden" name="currency_code" value="EUR">

--- a/scripts/paypal.js
+++ b/scripts/paypal.js
@@ -1,0 +1,9 @@
+const ejs = require('ejs');
+const path = require('path');
+const fs = require('fs');
+
+hexo.extend.tag.register('paypal', () => {
+  const htmlTmlSrc = path.join(__dirname, '..', 'layout', 'paypal.ejs');
+  const htmlTml = ejs.compile(fs.readFileSync(htmlTmlSrc, 'utf-8'));
+  return htmlTml({});
+})

--- a/source/css/_partial/paypal.styl
+++ b/source/css/_partial/paypal.styl
@@ -1,0 +1,21 @@
+.paypal {
+
+  &__selection {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    width: 70%;
+    justify-content: space-between;
+    padding: 0 16px 8px 16px;
+
+    &__details {
+    }
+
+    &__price {
+    }
+  }
+
+  &__button {
+    padding: 8px 16px 0;
+  }
+}

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -86,6 +86,7 @@ code
 @import "_partial/sidebar"
 @import "_partial/insight"
 @import "_partial/404"
+@import "_partial/paypal"
 @import "_partial/scrim"
 @import "_partial/calendar"
 @import "_partial/committee"


### PR DESCRIPTION
adds the ability to call `{% paypal %}` and insert a paypal joining form to any page

for [#154](https://github.com/redbrick/static-site/issues/154)