### PR TITLE
Fixed reversed newer and older links

### DIFF
--- a/layout/common/post/nav.ejs
+++ b/layout/common/post/nav.ejs
@@ -1,8 +1,20 @@
 <% if (post.prev || post.next) { %>
 <nav id="article-nav">
-    <% if (post.prev) { %>
-        <a href="<%- url_for(post.prev.path) %>" id="article-nav-newer" class="article-nav-link-wrap">
+    <% if (post.next) { %>
+        <a href="<%- url_for(post.next.path) %>" id="article-nav-newer" class="article-nav-link-wrap">
             <strong class="article-nav-caption"><%= __('nav.newer') %></strong>
+            <div class="article-nav-title">
+                <% if (post.next.title) { %>
+                    <%= post.next.title %>
+                <% } else { %>
+                    (no title)
+                <% } %>
+            </div>
+        </a>
+    <% } %>
+    <% if (post.prev) { %>
+        <a href="<%- url_for(post.prev.path) %>" id="article-nav-older" class="article-nav-link-wrap">
+            <strong class="article-nav-caption"><%= __('nav.older') %></strong>
             <div class="article-nav-title">
                 <% if (post.prev.title) { %>
                     <%= post.prev.title %>
@@ -10,12 +22,6 @@
                     (no title)
                 <% } %>
             </div>
-        </a>
-    <% } %>
-    <% if (post.next) { %>
-        <a href="<%- url_for(post.next.path) %>" id="article-nav-older" class="article-nav-link-wrap">
-            <strong class="article-nav-caption"><%= __('nav.older') %></strong>
-            <div class="article-nav-title"><%= post.next.title %></div>
         </a>
     <% } %>
 </nav>


### PR DESCRIPTION
Links for newer and older content on posts were reversed
so I fixed this. I also added in a check for older posts
to see if they have a title or not since this was only
present for newer posts before.